### PR TITLE
poc: release flow that matches requirements from golang sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "app-services-sdk-js-monorepo",
+  "version": "0.1.0",
   "private": true,
   "devDependencies": {},
   "scripts": {
@@ -9,6 +10,5 @@
   },
   "workspaces": [
     "packages/*"
-  ],
-  "version": "0.4.0"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "generate": "./scripts/generate.sh",
     "wrun": "yarn workspaces run",
-    "build":"yarn workspaces run build"
+    "build": "yarn workspaces run build"
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "0.4.0"
 }

--- a/scripts/lib/releaseFromTag
+++ b/scripts/lib/releaseFromTag
@@ -12,13 +12,23 @@ if (args.length != 1) {
 const tag = args[0];
 
 // Version in format: kafka-v0.0.1
-// TODO validate version
+
 const versionParts = tag.split("@");
 if (versionParts.length == 2) {
-  return console.log("yarn workspace @rhoas/" + versionParts[0] + "-sdk exec npm publish");
+  const name = versionParts[0];
+  const tagVersion = versionParts[1].substring(1);
+  const packageVersion =
+    require(`../../packages/${name}-sdk/package.json`).version;
+  if (packageVersion != tagVersion) {
+    throw new Error(
+      `Invalid tag. Tag should match package.json version: ${packageVersion} version: ${tagVersion}`
+    );
+  }
+  return console.log("yarn workspace @rhoas/" + name + "-sdk exec npm publish");
 }
 
-if (tag.substring(1).match(semverRegexp)) {
+const fullVersion = tag.substring(1);
+if (fullVersion.match(semverRegexp)) {
   // Full release of SDKs
   return console.log(`yarn workspace exec npm publish`);
 }

--- a/scripts/lib/releaseFromTag
+++ b/scripts/lib/releaseFromTag
@@ -11,7 +11,7 @@ if (args.length != 1) {
 
 const tag = args[0];
 
-// Version in format: kafka-v0.0.1
+// Version in format: kafka@v0.0.1
 
 const versionParts = tag.split("@");
 if (versionParts.length == 2) {

--- a/scripts/lib/releaseFromTag
+++ b/scripts/lib/releaseFromTag
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+
+const semverRegexp =
+  /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;
+
+if (args.length != 1) {
+  throw new Error("Invalid number of arguments" + args);
+}
+
+const tag = args[0];
+
+// Version in format: kafka-v0.0.1
+const versionParts = tag.split("@");
+if (versionParts.length == 2) {
+  return console.log("yarn workspace @rhoas/" + versionParts[0] + "-sdk");
+}
+
+if (tag.substring(1).match(semverRegexp)) {
+  // Full release of SDKs
+  return console.log(`yarn release:all`);
+}
+
+throw new Error("Invalid tag");

--- a/scripts/lib/releaseFromTag
+++ b/scripts/lib/releaseFromTag
@@ -12,14 +12,15 @@ if (args.length != 1) {
 const tag = args[0];
 
 // Version in format: kafka-v0.0.1
+// TODO validate version
 const versionParts = tag.split("@");
 if (versionParts.length == 2) {
-  return console.log("yarn workspace @rhoas/" + versionParts[0] + "-sdk");
+  return console.log("yarn workspace @rhoas/" + versionParts[0] + "-sdk exec npm publish");
 }
 
 if (tag.substring(1).match(semverRegexp)) {
   // Full release of SDKs
-  return console.log(`yarn release:all`);
+  return console.log(`yarn workspace exec npm publish`);
 }
 
 throw new Error("Invalid tag");

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,5 +7,4 @@ SCRIPT_DIR=`dirname $0`
 ## Pick right release based on tag structure
 EXEC=`$SCRIPT_DIR/lib/releaseFromTag $GITHUB_REF_SLUG`
 
-$EXEC 
- 
+$EXEC

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
+GITHUB_REF_SLUG=kafka-management@v0.0.1
 echo "Release process for TAG: $GITHUB_REF_SLUG"
 
+## Pick right release based on tag structure
+dirname $0`/lib/releaseFromTag $GITHUB_REF_SLUG`
+
+ 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,9 @@
 GITHUB_REF_SLUG=kafka-management@v0.0.1
 echo "Release process for TAG: $GITHUB_REF_SLUG"
 
+SCRIPT_DIR=`dirname $0`
 ## Pick right release based on tag structure
-dirname $0`/lib/releaseFromTag $GITHUB_REF_SLUG`
+EXEC=`$SCRIPT_DIR/lib/releaseFromTag $GITHUB_REF_SLUG`
 
+$EXEC 
  


### PR DESCRIPTION
Spike how we can release using the same process that was proposed in golang SDK:

1. Global tag releases everything under single version
2. Specific tag releases only single package