### PR TITLE
ci: stringify the payload when call fetch api script

### DIFF
--- a/.github/workflows/fetch_api_client.yaml
+++ b/.github/workflows/fetch_api_client.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       APP_SERVICES_TOKEN: ${{ secrets.CI_USER_TOKEN }}
       BF2_TOKEN: ${{ secrets.BF2_TOKEN }}
-      CLIENT_PAYLOAD: "${{ github.event.client_payload }}"
+      CLIENT_PAYLOAD: "${{ toJSON(github.event.client_payload) }}"
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Seeing this error when the github action is triggered:

```
The template is not valid. .github/workflows/fetch_api_client.yaml (Line: 11, Col: 23): A mapping was not expected
```

I think it's because the JSON object needs to be strigified.