### PR TITLE
ci: fix wrong secret name

### DIFF
--- a/.github/workflows/fetch_api_client.yaml
+++ b/.github/workflows/fetch_api_client.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   generate_client:
     env:
-      APP_SERVICES_TOKEN: ${{ secrets.CI_USER_TOKEN }}
+      APP_SERVICES_TOKEN: ${{ secrets.APP_SERVICES_TOKEN }}
       BF2_TOKEN: ${{ secrets.BF2_TOKEN }}
       CLIENT_PAYLOAD: "${{ toJSON(github.event.client_payload) }}"
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11743717/120615691-70925c80-c450-11eb-9d70-9f8bb4eefcfd.png)

It looks like the actual secret name is different to that which is defined in the action.