### PR TITLE
fix: update fetch api script and gh action

### DIFF
--- a/.github/workflows/fetch_api_client.yaml
+++ b/.github/workflows/fetch_api_client.yaml
@@ -8,7 +8,6 @@ jobs:
     env:
       APP_SERVICES_TOKEN: ${{ secrets.APP_SERVICES_TOKEN }}
       BF2_TOKEN: ${{ secrets.BF2_TOKEN }}
-      CLIENT_PAYLOAD: "${{ toJSON(github.event.client_payload) }}"
 
     runs-on: ubuntu-latest
     steps:
@@ -17,7 +16,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get install jq
       - name: Fetch OpenAPI doc
-        run: ./scripts/fetch_api.sh
+        run: ./scripts/fetch_api.sh ${{ github.event.client_payload.download_url }}
       - name: Generate SDKs
         run: ./scripts/generate.sh
       - uses: peter-evans/create-pull-request@v3

--- a/scripts/fetch_api.sh
+++ b/scripts/fetch_api.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 # get the download URL of the OpenAPI spec file
-OPENAPI_FILE_URL=`echo $CLIENT_PAYLOAD | jq .download_url`
+OPENAPI_FILE_URL=$1
+OPENAPI_FILE_NAME=$(dirname $0)/../.openapi/$(basename $OPENAPI_FILE_URL)
 
 # download the OpenAPI file
-curl -H "Authorization: token $BF2_TOKEN" "$OPENAPI_FILE_URL"
+curl -H "Authorization: token $BF2_TOKEN" "$OPENAPI_FILE_URL" --output $OPENAPI_FILE_NAME
 if [ $? != 0 ]; then
   exit $?
 fi


### PR DESCRIPTION
The current workflow isn't working as expect for automatically generate the sdk when the kas-fleet-manager API changes. This PR should fix it.