### PR TITLE
chore: update api client job

### DIFF
--- a/.github/workflows/fetch_api_client.yaml
+++ b/.github/workflows/fetch_api_client.yaml
@@ -17,8 +17,6 @@ jobs:
         run: sudo apt-get install jq
       - name: Fetch OpenAPI doc
         run: ./scripts/fetch_api.sh ${{ github.event.client_payload.download_url }}
-      - name: Generate SDKs
-        run: ./scripts/generate.sh
       - uses: peter-evans/create-pull-request@v3
         with:
           title: "Update API client"
@@ -28,4 +26,13 @@ jobs:
           delete-branch: true
           reviewers: craicoverflow, wtrocki
           body: |
-            Auto-generated API client
+            Auto-generated API client for ${{ github.event.client_payload.id }}
+            
+            ## SDK update procedure
+
+            1. Review changes on OpenAPI file and validate if they are correct
+            2. Perform manual changes if needed or apply local patches for the OpenAPI files 
+            3. Merge PR 
+            4. Regenerate API using `yarn generate` and verify if underlying clients and examples are functional
+            5. Create PR and merge changes to main
+            6. Perform release on github with new changes


### PR DESCRIPTION
Add more info to the PR that will contain instructions how to make SDK released for everyone. 
As we see there is quite set of manual steps right now but this can be automated further later on.