### PR TITLE
feat(api-mock): enable dynamic reset of consumer offsets

### DIFF
--- a/packages/api-mock/README.md
+++ b/packages/api-mock/README.md
@@ -31,7 +31,7 @@ npm install -g @rhoas/api-mock
 asapi
 ```
 
-Optionally pre-seed with data:
+Starting mock with sample data present:
 
 ```shell
 asapi --pre-seed

--- a/packages/api-mock/README.md
+++ b/packages/api-mock/README.md
@@ -31,6 +31,12 @@ npm install -g @rhoas/api-mock
 asapi
 ```
 
+Optionally pre-seed with data:
+
+```shell
+asapi --pre-seed
+```
+
 ### Instances API mapping pattern
 
 Mock provides instances (data) API mock as well as the control planes.

--- a/packages/api-mock/package.json
+++ b/packages/api-mock/package.json
@@ -28,7 +28,8 @@
     "cors": "2.8.5",
     "express": "4.17.1",
     "nanoid": "3.1.23",
-    "openapi-backend": "4.1.0"
+    "openapi-backend": "4.1.0",
+    "yargs": "^17.0.1"
   },
   "devDependencies": {
     "axios": "0.21.1",

--- a/packages/api-mock/src/handlers/kafka-manager.js
+++ b/packages/api-mock/src/handlers/kafka-manager.js
@@ -23,169 +23,174 @@ const commonError = {
   operation_id: "1iWIimqGcrDuL61aUxIZqBTqNRa",
 };
 
-const kafkas = {
-  // If you want initial data uncomment those fields
-  // uFYJpM76DaIqVqqgZjtrz: {
-  //   id: "uFYJpM76DaIqVqqgZjtrz",
-  //   kind: "kafka",
-  //   href: "/api/kafkas_mgmt/v1/kafkas/1iSY6RQ3JKI8Q0OTmjQFd3ocFRg",
-  //   owner: "api_kafka_user",
-  //   name: "sample-kafka",
-  //   ...commonKafkaFields,
-  // },
-};
+const kafkas = {};
 
-module.exports = {
-  createKafka: async (c, req, res) => {
-    if (!req.body.name) {
-      return res.status(400).json({
-        reason: "Missing name field",
-        ...commonError,
-      });
-    }
-    const newId = nanoid();
-    const kafka = {
-      id: newId,
-      href: "/api/kafkas_mgmt/v1/kafkas/" + newId,
-      ...req.body,
+function createKafkaHandlers(preSeed) {
+  if (preSeed) {
+    kafkas['uFYJpM76DaIqVqqgZjtrz'] = {
+      id: "uFYJpM76DaIqVqqgZjtrz",
+      kind: "kafka",
+      href: "/api/kafkas_mgmt/v1/kafkas/1iSY6RQ3JKI8Q0OTmjQFd3ocFRg",
+      owner: "api_kafka_user",
+      name: "sample-kafka",
       ...commonKafkaFields,
-    };
-    kafkas[newId] = kafka;
-    res.status(202).json(kafka);
-  },
-
-  deleteKafkaById: async (c, req, res) => {
-    const id = c.request.params.id;
-    if (!id || !kafkas[id]) {
-      return res.status(400).json({
-        reason: "Missing or invalid id field",
-        ...commonError,
-      });
     }
+  }
+  
+  return {
+    createKafka: async (c, req, res) => {
+      if (!req.body.name) {
+        return res.status(400).json({
+          reason: "Missing name field",
+          ...commonError,
+        });
+      }
+      const newId = nanoid();
+      const kafka = {
+        id: newId,
+        href: "/api/kafkas_mgmt/v1/kafkas/" + newId,
+        ...req.body,
+        ...commonKafkaFields,
+      };
+      kafkas[newId] = kafka;
+      res.status(202).json(kafka);
+    },
 
-    const kafka = Object.assign({}, kafkas[id]);
-    delete kafkas[id];
-    res.status(204).json(kafka);
-  },
+    deleteKafkaById: async (c, req, res) => {
+      const id = c.request.params.id;
+      if (!id || !kafkas[id]) {
+        return res.status(400).json({
+          reason: "Missing or invalid id field",
+          ...commonError,
+        });
+      }
 
-  getKafkaById: async (c, req, res) => {
-    const id = c.request.params.id;
-    if (!id || !kafkas[id]) {
-      return res.status(400).json({
-        reason: "Missing or invalid id field",
-        ...commonError,
+      const kafka = Object.assign({}, kafkas[id]);
+      delete kafkas[id];
+      res.status(204).json(kafka);
+    },
+
+    getKafkaById: async (c, req, res) => {
+      const id = c.request.params.id;
+      if (!id || !kafkas[id]) {
+        return res.status(400).json({
+          reason: "Missing or invalid id field",
+          ...commonError,
+        });
+      }
+
+      res.status(200).json(kafkas[id]);
+    },
+
+    getKafkas: async (c, req, res) => {
+      return res.status(200).json({
+        kind: "KafkaRequestList",
+        page: 1,
+        size: 50,
+        total: kafkas.length,
+        items: Object.values(kafkas),
       });
-    }
+    },
 
-    res.status(200).json(kafkas[id]);
-  },
+    getCloudProviders: async (_c, _req, res) => {
+      return res.status(200).json({
+        kind: "CloudProviderList",
+        page: 1,
+        size: 7,
+        total: 7,
+        items: [
+          {
+            kind: "CloudProvider",
+            id: "aws",
+            display_name: "Amazon Web Services",
+            name: "aws",
+            enabled: true,
+          },
+          {
+            kind: "CloudProvider",
+            id: "azure",
+            display_name: "Microsoft Azure",
+            name: "azure",
+            enabled: false,
+          },
+        ],
+      });
+    },
 
-  getKafkas: async (c, req, res) => {
-    return res.status(200).json({
-      kind: "KafkaRequestList",
-      page: 1,
-      size: 50,
-      total: kafkas.length,
-      items: Object.values(kafkas),
-    });
-  },
+    getCloudProviderRegions: async (_c, _req, res) => {
+      return res.status(200).json({
+        kind: "CloudRegionList",
+        page: 1,
+        size: 17,
+        total: 17,
+        items: [
+          {
+            kind: "CloudRegion",
+            id: "eu-west-2",
+            display_name: "EU, London",
+            enabled: true,
+          },
+        ],
+      });
+    },
 
-  getCloudProviders: async (_c, _req, res) => {
-    return res.status(200).json({
-      kind: "CloudProviderList",
-      page: 1,
-      size: 7,
-      total: 7,
-      items: [
-        {
-          kind: "CloudProvider",
-          id: "aws",
-          display_name: "Amazon Web Services",
-          name: "aws",
-          enabled: true,
-        },
-        {
-          kind: "CloudProvider",
-          id: "azure",
-          display_name: "Microsoft Azure",
-          name: "azure",
-          enabled: false,
-        },
-      ],
-    });
-  },
+    getVersionMetadata: async (c, req, res) =>
+      res.status(200).json({
+        kind: "APIVersion",
+        id: "v1",
+        collections: [{ id: "kafkas", kind: "KafkaList" }],
+      }),
 
-  getCloudProviderRegions: async (_c, _req, res) => {
-    return res.status(200).json({
-      kind: "CloudRegionList",
-      page: 1,
-      size: 17,
-      total: 17,
-      items: [
-        {
-          kind: "CloudRegion",
-          id: "eu-west-2",
-          display_name: "EU, London",
-          enabled: true,
-        },
-      ],
-    });
-  },
+    createServiceAccount: async (c, req, res) => {
+      const clientId = Number.MAX_SAFE_INTEGER - new Date().getTime();
+      const clientSecret = Number.MAX_SAFE_INTEGER - new Date().getTime();
+      res.status(200).json({
+        name: req.body.name,
+        description: req.body.description,
+        client_id: clientId.toString(),
+        client_secret: clientSecret.toString(),
+      });
+    },
 
-  getVersionMetadata: async (c, req, res) =>
-    res.status(200).json({
-      kind: "APIVersion",
-      id: "v1",
-      collections: [{ id: "kafkas", kind: "KafkaList" }],
-    }),
+    getServiceAccounts: async (c, req, res) => {
+      res.status(200).json(saList);
+    },
 
-  createServiceAccount: async (c, req, res) => {
-    const clientId = Number.MAX_SAFE_INTEGER - new Date().getTime();
-    const clientSecret = Number.MAX_SAFE_INTEGER - new Date().getTime();
-    res.status(200).json({
-      name: req.body.name,
-      description: req.body.description,
-      client_id: clientId.toString(),
-      client_secret: clientSecret.toString(),
-    });
-  },
+    getServiceAccountById: async (c, req, res) => {
+      res.status(200).json({
+        id: "1",
+        kind: "ServiceAccount",
+        href: "/api/managed-services-api/v1/serviceaccounts/1",
+        name: "my-app-sa",
+        description: "service account for my app",
+        client_id: "SA-121212",
+        owner: "test-user",
+        created_at: "2021-04-07T16:24:01+05:30",
+      });
+    },
 
-  getServiceAccounts: async (c, req, res) => {
-    res.status(200).json(saList);
-  },
+    deleteServiceAccount: async (c, req, res) => {
+      res.status(200).json({
+        id: "1",
+        kind: "ServiceAccount",
+        href: "/api/managed-services-api/v1/serviceaccounts/1",
+        name: "my-app-sa",
+        description: "service account for my app",
+        client_id: "SA-121212",
+        owner: "test-user",
+        created_at: "2021-04-07T16:24:01+05:30",
+      });
+    },
 
-  getServiceAccountById: async (c, req, res) => {
-    res.status(200).json({
-      id: "1",
-      kind: "ServiceAccount",
-      href: "/api/managed-services-api/v1/serviceaccounts/1",
-      name: "my-app-sa",
-      description: "service account for my app",
-      client_id: "SA-121212",
-      owner: "test-user",
-      created_at: "2021-04-07T16:24:01+05:30",
-    });
-  },
+    getServiceStatus: async (c, req, res) => {
+      res.status(200).json({});
+    },
 
-  deleteServiceAccount: async (c, req, res) => {
-    res.status(200).json({
-      id: "1",
-      kind: "ServiceAccount",
-      href: "/api/managed-services-api/v1/serviceaccounts/1",
-      name: "my-app-sa",
-      description: "service account for my app",
-      client_id: "SA-121212",
-      owner: "test-user",
-      created_at: "2021-04-07T16:24:01+05:30",
-    });
-  },
+    // Handling auth
+    notFound: async (c, req, res) => res.status(404).json({ err: "not found" }),
+    unauthorizedHandler: async (c, req, res) =>
+      res.status(401).json({ err: "unauthorized" }),
+  }
+}
 
-  getServiceStatus: async (c, req, res) => {
-    res.status(200).json({});
-  },
-
-  // Handling auth
-  notFound: async (c, req, res) => res.status(404).json({ err: "not found" }),
-  unauthorizedHandler: async (c, req, res) =>
-    res.status(401).json({ err: "unauthorized" }),
-};
+module.exports = createKafkaHandlers

--- a/packages/api-mock/src/handlers/registry-manager.js
+++ b/packages/api-mock/src/handlers/registry-manager.js
@@ -20,79 +20,81 @@ const commonError = {
   operation_id: "1iWIimqGcrDuL61aUxIZqBTqNRa",
 };
 
-const registries = {
-  // If you want initial data uncomment those fields
-  // llmNteR4P7waRp5nJIReG: {
-  //   id: "llmNteR4P7waRp5nJIReG",
-  //   href: "/api/serviceregistry_mgmt/v1/registries/llmNteR4P7waRp5nJIReG",
-  //   name: "sample-registry",
-  //   ...commonFields,
-  // },
-};
+const registries = {};
 
-module.exports = {
-  getRegistries: async (c, req, res) => {
-    res.status(200).json({
-      kind: "RegistryRestList",
-      page: 1,
-      size: 50,
-      total: registries.length,
-      items: Object.values(registries),
-    });
-  },
-
-  createRegistry: async (c, req, res) => {
-    if (!req.body.name) {
-      return res.status(400).json({
-        reason: "Missing name field",
-        ...commonError,
-      });
-    }
-    
-    const newId = nanoid();
-    const registry = {
-      id: newId,
-      href: "/api/registries_mgmt/v1/serviceregistry/" + newId,
-      ...req.body,
+module.exports = function createRegistryHandlers(preSeed) {
+  if (preSeed) {
+    registries['llmNteR4P7waRp5nJIReG'] = {
+      id: "llmNteR4P7waRp5nJIReG",
+      href: "/api/serviceregistry_mgmt/v1/registries/llmNteR4P7waRp5nJIReG",
+      name: "sample-registry",
       ...commonFields,
-    };
-    registries[newId] = registry;
-    res.status(200).json(registries);
-  },
-
-  getRegistry: async (c, req, res) => {
-    if (
-      !c.request.params.registryId ||
-      !registries[c.request.params.registryId]
-    ) {
-      return res.status(400).json({
-        reason: "Missing or invalid id field",
-        ...commonError,
-      });
     }
-
-    res.status(200).json(registries[c.request.params.registryId]);
-  },
-
-  deleteRegistry: async (c, req, res) => {
-    const id = c.request.params.registryId;
-    if (
-      !id ||
-      !registries[id]
-    ) {
-      return res.status(400).json({
-        reason: "Missing or invalid id field",
-        ...commonError,
+  }
+  return {
+    getRegistries: async (c, req, res) => {
+      res.status(200).json({
+        kind: "RegistryRestList",
+        page: 1,
+        size: 50,
+        total: registries.length,
+        items: Object.values(registries),
       });
-    }
+    },
 
-    const registry = registries[id];
-    delete registries[id];
-    res.status(204).json(registry);
-  },
+    createRegistry: async (c, req, res) => {
+      if (!req.body.name) {
+        return res.status(400).json({
+          reason: "Missing name field",
+          ...commonError,
+        });
+      }
 
-  // Handling auth
-  notFound: async (c, req, res) => res.status(404).json({ err: "not found" }),
-  unauthorizedHandler: async (c, req, res) =>
-    res.status(401).json({ err: "unauthorized" }),
-};
+      const newId = nanoid();
+      const registry = {
+        id: newId,
+        href: "/api/registries_mgmt/v1/serviceregistry/" + newId,
+        ...req.body,
+        ...commonFields,
+      };
+      registries[newId] = registry;
+      res.status(200).json(registries);
+    },
+
+    getRegistry: async (c, req, res) => {
+      if (
+        !c.request.params.registryId ||
+        !registries[c.request.params.registryId]
+      ) {
+        return res.status(400).json({
+          reason: "Missing or invalid id field",
+          ...commonError,
+        });
+      }
+
+      res.status(200).json(registries[c.request.params.registryId]);
+    },
+
+    deleteRegistry: async (c, req, res) => {
+      const id = c.request.params.registryId;
+      if (
+        !id ||
+        !registries[id]
+      ) {
+        return res.status(400).json({
+          reason: "Missing or invalid id field",
+          ...commonError,
+        });
+      }
+
+      const registry = registries[id];
+      delete registries[id];
+      res.status(204).json(registry);
+    },
+
+    // Handling auth
+    notFound: async (c, req, res) => res.status(404).json({ err: "not found" }),
+    unauthorizedHandler: async (c, req, res) =>
+      res.status(401).json({ err: "unauthorized" }),
+  };
+}

--- a/packages/api-mock/src/index.js
+++ b/packages/api-mock/src/index.js
@@ -12,7 +12,7 @@ const preSeed = argv.preSeed
 const OpenAPIBackend = require("openapi-backend").default;
 const express = require("express");
 const createKafkaHandlers = require("./handlers/kafka-manager");
-const srsHandlers = require("./handlers/registry-manager");
+const createRegistryHandlers = require("./handlers/registry-manager");
 const srsDataHandlers = require("./handlers/registry-data");
 const topicHandlers = require("./handlers/kafka-admin");
 const ams = require("./handlers/ams");
@@ -44,7 +44,7 @@ const srsDataApi = new OpenAPIBackend({
 // register handlers
 kafkaAPI.register(createKafkaHandlers(preSeed));
 topicAPI.register(topicHandlers);
-srsControlApi.register(srsHandlers);
+srsControlApi.register(createRegistryHandlers(preSeed));
 srsDataApi.register(srsDataHandlers);
 
 // register security handler

--- a/packages/api-mock/src/index.js
+++ b/packages/api-mock/src/index.js
@@ -1,11 +1,17 @@
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
+const argv = yargs(hideBin(process.argv)).boolean('pre-seed').argv
+
 // env setup
 if (!process.env.CUSTOM_OWNER) {
   process.env.CUSTOM_OWNER = "Missing RESOURCE_OWNER";
 }
 
+const preSeed = argv.preSeed
+
 const OpenAPIBackend = require("openapi-backend").default;
 const express = require("express");
-const kafkaHandlers = require("./handlers/kafka-manager");
+const createKafkaHandlers = require("./handlers/kafka-manager");
 const srsHandlers = require("./handlers/registry-manager");
 const srsDataHandlers = require("./handlers/registry-data");
 const topicHandlers = require("./handlers/kafka-admin");
@@ -36,7 +42,7 @@ const srsDataApi = new OpenAPIBackend({
 });
 
 // register handlers
-kafkaAPI.register(kafkaHandlers);
+kafkaAPI.register(createKafkaHandlers(preSeed));
 topicAPI.register(topicHandlers);
 srsControlApi.register(srsHandlers);
 srsDataApi.register(srsDataHandlers);


### PR DESCRIPTION
This PR does two things:

- You can pre-seed the mock server by passing `--pre-seed`
- Updated the `resetConsumerGroupOffset` handler to give the ability to dynamically reset offset based on parameters.