### PR TITLE
fix: add states for sample consumergroups

### DIFF
--- a/packages/api-mock/_data_/consumer-groups.json
+++ b/packages/api-mock/_data_/consumer-groups.json
@@ -1,6 +1,7 @@
 [
   {
     "groupId": "consumer_group_1",
+    "state": "STABLE",
     "consumers": [
       {
         "groupId": "consumer_group_1",
@@ -33,6 +34,7 @@
   },
   {
     "groupId": "consumer_group_2",
+    "state": "STABLE",
     "consumers": [
       {
         "groupId": "consumer_group_2",
@@ -56,6 +58,7 @@
   },
   {
     "groupId": "consumer_group_3",
+    "state": "DEAD",
     "consumers": [
       {
         "groupId": "consumer_group_3",
@@ -79,6 +82,7 @@
   },
   {
     "groupId": "consumer_group_4",
+    "state": "EMPTY",
     "consumers": [
       {
         "groupId": "consumer_group_4",
@@ -102,6 +106,7 @@
   },
   {
     "groupId": "consumer_group_5",
+    "state": "UNKNOWN",
     "consumers": [
       {
         "groupId": "consumer_group_5",


### PR DESCRIPTION
Mock server should have a field `state` for Kafka consumer groups.

https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/blob/baebfcfa5fb7901300b9c5d3d3b73483be18efc8/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml#L1034