### PR TITLE
fix(mock): check value only for certain offsets

### DIFF
--- a/packages/api-mock/src/handlers/kafka-admin.js
+++ b/packages/api-mock/src/handlers/kafka-admin.js
@@ -70,8 +70,17 @@ module.exports = {
     const id = c.request.params.consumerGroupId;
     const payload = c.request.body;
 
-    if (!payload || !payload.length && !payload.offset || !payload.value) {
+    if (!payload || !payload.length && !payload.offset) {
       return res.status(400).json({ error_message: 'missing request body' })
+    }
+
+
+    if(!payload.value && payload.offset !== "latest" && payload.offset !== "earliest") {
+      return res.status(400).json({ error_message: `Value has to be set when ${payload.offset} offset is used.`})
+    }
+
+    if((payload.offset === "latest" || payload.offset === "earliest") && payload.value) {
+      return res.status(400).json({ error_message: `Value can't be used when ${payload.offset} offset is used.`})
     }
 
     const group = getConsumerGroup(id);


### PR DESCRIPTION
Mock throws a 400 error if `value` is not provided. Value is optional and is need for offsets - `Absolute` and `Timestamp`.

Following PR makes it optional and checks for it only when offset type is `Absolute` or `Timestamp`.

[[Reference link]](https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/blob/b5a4f38aed8673773c40a7bcfe7bed76a91cc677/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java#L156)