### PR TITLE
fix(api-mock): update reset offset response to new open api type

### DIFF
--- a/packages/api-mock/src/handlers/kafka-admin.js
+++ b/packages/api-mock/src/handlers/kafka-admin.js
@@ -121,7 +121,16 @@ module.exports = {
     consumerGroups = consumerGroups.filter((t) => t.groupId !== id);
     consumerGroups.push(group);
 
-    return res.status(200).json(group);
+    const updatedConsumers = group.consumers.map(({ topic, partition, offset }) => ({
+      topic,
+      partition,
+      offset
+    }))
+
+    return res.status(200).json({
+      items: updatedConsumers,
+      total: updatedConsumers.length
+    });
   },
 
   createTopic: async (c, req, res) => {


### PR DESCRIPTION
### Description

The response for reset offset earlier returned consumer-group data. It has been updated now to comply with the schema specified in [latest OpenAPI specs](https://github.com/redhat-developer/app-services-sdk-js/blob/4ce530481d452b7aaa9c79b859d3690b0a97dbbf/.openapi/kafka-admin-rest.yaml#L1225).

### Additional context

Have tested it against go-sdk using the cli, no unmarshalling error!