### PR TITLE
fix(mock): update ams handler methods with return statement

### DIFF
--- a/packages/api-mock/src/handlers/ams.js
+++ b/packages/api-mock/src/handlers/ams.js
@@ -13,17 +13,17 @@ module.exports = {
   },
   // Simulate a user account
   currentAccount: (req, res) => {
-    res.json(CurrentAccount);
+    return res.json(CurrentAccount);
   },
   // Mock a summary of quota cost
   quotaCostGet: (req, res) => {
     switch(process.env.AMS_QUOTA_TYPE) {
       case "trial":
-        res.json(QuotaCostList.trial);
+        return res.json(QuotaCostList.trial);
       case "standard":
-        res.json(QuotaCostList.standard);
+        return res.json(QuotaCostList.standard);
       case "marketplace": default:
-        res.json(QuotaCostList.marketPlace);
+        return res.json(QuotaCostList.marketPlace);
     }
   },
 };


### PR DESCRIPTION
Mock showed warning in console regarding setting headers after returning response. This needed return statements to be added to the handlers.