### PR TITLE
Return 404 if the kafka instance is not found

### DIFF
--- a/packages/api-mock/_data_/cloudProviders.json
+++ b/packages/api-mock/_data_/cloudProviders.json
@@ -1,0 +1,16 @@
+[
+    {
+        "kind": "CloudProvider",
+        "id": "aws",
+        "display_name": "Amazon Web Services",
+        "name": "aws",
+        "enabled": true
+    },
+    {
+        "kind": "CloudProvider",
+        "id": "azure",
+        "display_name": "Microsoft Azure",
+        "name": "azure",
+        "enabled": false
+    }
+]

--- a/packages/api-mock/src/handlers/kafka-manager.js
+++ b/packages/api-mock/src/handlers/kafka-manager.js
@@ -3,6 +3,9 @@ const path = require("path");
 const { getFullHostname } = require("../utls/host");
 var saList = require("../../_data_/serviceaccounts.json");
 
+const cloudProviders = require("../../_data_/cloudProviders.json");
+var providers = cloudProviders.map(cloudProvider => cloudProvider.id)
+
 const commonKafkaFields = {
   kind: "Kafka",
   status: "ready",
@@ -41,25 +44,6 @@ const commonError = {
 };
 
 const kafkas = {};
-
-const cloudProviders = [
-  {
-    kind: "CloudProvider",
-    id: "aws",
-    display_name: "Amazon Web Services",
-    name: "aws",
-    enabled: true,
-  },
-  {
-    kind: "CloudProvider",
-    id: "azure",
-    display_name: "Microsoft Azure",
-    name: "azure",
-    enabled: false,
-  },
-]
-
-var providers = cloudProviders.map(cloudProvider => cloudProvider.id)
 
 function createKafkaHandlers(preSeed) {
   if (preSeed) {

--- a/packages/api-mock/src/handlers/kafka-manager.js
+++ b/packages/api-mock/src/handlers/kafka-manager.js
@@ -98,6 +98,7 @@ function createKafkaHandlers(preSeed) {
         ...req.body,
         ...commonKafkaFields,
       };
+      kafka["cloud_provider"] = cloudProvider;
       kafkas[newId] = kafka;
       res.status(202).json(kafka);
     },

--- a/packages/api-mock/src/handlers/kafka-manager.js
+++ b/packages/api-mock/src/handlers/kafka-manager.js
@@ -82,11 +82,11 @@ function createKafkaHandlers(preSeed) {
         });
       }
 
-      let cloudProvider = c.request.params.cloud_provider || commonKafkaFields.cloud_provider
+      let cloudProvider = req.body.cloud_provider || commonKafkaFields.cloud_provider
 
       if (!providers.includes(cloudProvider)) {
         return res.status(400).json({
-          reason: `provider ${c.request.params.cloud_provider} is not supported, supported providers are: ${listProviders.join(", ")}`,
+          reason: `provider '${req.body.cloud_provider}' is not supported, supported providers are: ${providers.join(", ")}`,
           ...commonError,
         });
       }


### PR DESCRIPTION
Fix https://github.com/redhat-developer/terraform-provider-rhoas/issues/47

## How to check

Install with:

```
yarn
yarn build
yarn start
```

Run a curl:

1. Old code:

```
❯ curl localhost:8000/api/kafkas_mgmt/v1/kafkas/my_test_kafka| jq
{
  "reason": "Missing or invalid id field",
  "id": "103",
  "kind": "Error",
  "href": "/api/kafkas_mgmt/v1/errors/103",
  "code": "KAFKAS-MGMT-103",
  "operation_id": "1iWIimqGcrDuL61aUxIZqBTqNRa"
}
```

2. New code:
```
❯ curl localhost:8000/api/kafkas_mgmt/v1/kafkas/my_test_kafka| jq
{
  "reason": "not found",
  "id": "103",
  "kind": "Error",
  "href": "/api/kafkas_mgmt/v1/errors/103",
  "code": "KAFKAS-MGMT-103",
  "operation_id": "1iWIimqGcrDuL61aUxIZqBTqNRa"
}
```

How to check the provider changes:

```
❯ curl -X 'POST' \
  'http://localhost:8000/api/kafkas_mgmt/v1/kafkas?async=false' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "region": "us-east-1",
  "cloud_provider": "not aws",
  "name": "serviceapitest"
}' | jq
{
  "reason": "provider 'not aws' is not supported, supported providers are: aws, azure",
  "id": "103",
  "kind": "Error",
  "href": "/api/kafkas_mgmt/v1/errors/103",
  "code": "KAFKAS-MGMT-103",
  "operation_id": "1iWIimqGcrDuL61aUxIZqBTqNRa"
}
```

```
❯ curl -X 'POST' \
  'http://localhost:8000/api/kafkas_mgmt/v1/kafkas?async=false' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "region": "us-east-1", "cloud_provider": "azure",
  "name": "serviceapitest"
}' | jq
{
  "id": "uezBGG3-Wo7NNamhdxHL3",
  "href": "/api/kafkas_mgmt/v1/kafkas/uezBGG3-Wo7NNamhdxHL3",
  "region": "us-east-1",
  "cloud_provider": "azure",
  "name": "serviceapitest",
  "kind": "Kafka",
  "status": "ready",
  "multi_az": false,
  "bootstrap_server_host": "localhost:8000",
  "created_at": "2020-10-05T12:51:24.053142Z",
  "updated_at": "2020-10-05T12:56:36.362208Z",
  "marketplace": "standard",
  "admin_api_server_url": "http://localhost:8000/data/kafka",
  "browser_url": "http://localhost:8080/calbu9ccff6bdd4jsg30/dashboard",
  "billing_cloud_account_id": "123456789012",
  "egress_throughput_per_sec": "1Mi",
  "expires_at": "2022-06-18T05:27:01.816619Z",
  "ingress_throughput_per_sec": "1Mi",
  "instance_type": "developer",
  "instance_type_name": "Trial",
  "kafka_storage_size": "10Gi",
  "max_connection_attempts_per_sec": 50,
  "max_data_retention_period": "P14D",
  "max_partitions": 100,
  "reauthentication_enabled": true,
  "size_id": "x1",
  "total_max_connections": 100,
  "version": "3.0.1"
}
```