### PR TITLE
feat(mock): add mock ACL data

### DIFF
--- a/packages/api-mock/_data_/ACLs.json
+++ b/packages/api-mock/_data_/ACLs.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "kind": "AclBinding",
+      "operation": "DESCRIBE",
+      "patternType": "LITERAL",
+      "permission": "ALLOW",
+      "principal": "User:*",
+      "resourceName": "*",
+      "resourceType": "CLUSTER"
+    },
+    {
+      "kind": "AclBinding",
+      "operation": "DESCRIBE",
+      "patternType": "LITERAL",
+      "permission": "ALLOW",
+      "principal": "User:*",
+      "resourceName": "*",
+      "resourceType": "GROUP"
+    },
+    {
+      "kind": "AclBinding",
+      "operation": "DESCRIBE",
+      "patternType": "LITERAL",
+      "permission": "ALLOW",
+      "principal": "User:*",
+      "resourceName": "*",
+      "resourceType": "TOPIC"
+    },
+    {
+      "kind": "AclBinding",
+      "operation": "DESCRIBE_CONFIGS",
+      "patternType": "LITERAL",
+      "permission": "ALLOW",
+      "principal": "User:*",
+      "resourceName": "*",
+      "resourceType": "TOPIC"
+    }
+  ],
+  "kind": "AclBindingList",
+  "page": 1,
+  "size": 10,
+  "total": 4
+}

--- a/packages/api-mock/src/handlers/kafka-admin.js
+++ b/packages/api-mock/src/handlers/kafka-admin.js
@@ -1,5 +1,6 @@
 var topics = require('../../_data_/topics.json');
 var consumerGroups = require('../../_data_/consumer-groups.json');
+var ACLs = require('../../_data_/ACLs.json');
 
 module.exports = {
   getConsumerGroups: async (c, req, res) => {
@@ -259,6 +260,19 @@ module.exports = {
     }
 
     return res.status(200).json(topic);
+  },
+
+  createAcl: async (c, _, res) => {
+
+    let ACLBody = c.request.body;
+    ACLBody.kind = "AclBinding"
+    ACLs.items.push(ACLBody);
+
+    return res.status(201).end();
+  },
+
+  getAcls: async (c, _, res) => {
+    return res.status(200).json(ACLs);
   },
 
   // Handling auth


### PR DESCRIPTION
ACL sample data has been added to the mock.

Currently only two handlers are being supported - create and get ACLs. More handlers will be added subsequently.