### PR TITLE
fix: fixes a bug by where the returned response conflicts with OAS file

### DIFF
--- a/packages/api-mock/src/handlers/kafka-admin.js
+++ b/packages/api-mock/src/handlers/kafka-admin.js
@@ -150,7 +150,7 @@ module.exports = {
       name: topicBody.name,
       config: topicBody.settings.config,
       partitions: createPartitions(
-        topicBody.settings.numPartitions,
+        topicBody.settings.partition,
         topicBody.settings.replicationFactor
       ),
     };
@@ -238,8 +238,8 @@ module.exports = {
     }
 
     const topic = getTopic(topicName);
-    if (topicBody.numPartitions) {
-      topic.partitions = createPartitions(topicBody.numPartitions, 2);
+    if (topicBody.partition) {
+      topic.partitions = createPartitions(topicBody.partition, 2);
     }
 
     if (topicBody.config) {


### PR DESCRIPTION
 The Python SDK client doesn't recognise `numPartitions` as it is looking for `partition` in the response body. 
This may effect other clients, I'm unsure. 

@jackdelahunt if you try create a topic against the mock, do you run into any issues with the Go SDK failing to decode the partition value?

here is the error returned by python SDK:

```
rhoas_kafka_instance_sdk.exceptions.ApiValueError: Invalid inputs given to generate an instance of 'TopicAllOf'. The input data was invalid for the allOf schema 'TopicAllOf' in the composed schema 'Topic'. Error=_from_openapi_data() missing 1 required positional argument: 'partition'
```