### PR TITLE
feat: added service account api

### DIFF
--- a/packages/api-mock/src/handlers/service-account-manager.js
+++ b/packages/api-mock/src/handlers/service-account-manager.js
@@ -1,0 +1,43 @@
+const nanoid = require("nanoid").nanoid;
+const path = require("path");
+const { getFullHostname } = require("../utls/host");
+
+const commonServiceAccountFields = {
+    id: "service-account-id",
+    clientId: "service-account-client-id",
+    secret: "service-account-secret",
+    name: "service-account-name",
+    description: "service-account-description",
+    createdBy: "service-account-created-by",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+}
+
+function createServiceAccountHandlers(preSeed) {
+    
+    return {
+      createServiceAccount: async (c, req, res) => {
+        const clientId = Number.MAX_SAFE_INTEGER - new Date().getTime();
+        const clientSecret = Number.MAX_SAFE_INTEGER - new Date().getTime();
+        res.status(200).json({
+          name: req.body.name,
+          description: req.body.description,
+          client_id: clientId.toString(),
+          client_secret: clientSecret.toString(),
+        });
+      },
+  
+      getServiceAccounts: async (c, req, res) => {
+        res.status(200).json(saList);
+      },
+  
+      
+      // Handling auth
+      notFound: async (c, req, res) => res.status(404).json({ err: "not found" }),
+      unauthorizedHandler: async (c, req, res) => {
+        res.status(401).json({ err: "unauthorized" })
+    },
+    }
+  }
+
+module.exports = createServiceAccountHandlers

--- a/packages/api-mock/src/handlers/service-account-manager.js
+++ b/packages/api-mock/src/handlers/service-account-manager.js
@@ -2,41 +2,70 @@ const nanoid = require("nanoid").nanoid;
 const path = require("path");
 const { getFullHostname } = require("../utls/host");
 
+let serviceAccountMap = new Map();
+
 const commonServiceAccountFields = {
-    id: "service-account-id",
-    clientId: "service-account-client-id",
-    secret: "service-account-secret",
+    id: nanoid(),
+    clientId: nanoid(),
+    secret: nanoid(),
     name: "service-account-name",
     description: "service-account-description",
     createdBy: "service-account-created-by",
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString()
+    createdAt: new Date().getTime(),
 }
 
 function createServiceAccountHandlers(preSeed) {
     
     return {
       createServiceAccount: async (c, req, res) => {
-        const clientId = Number.MAX_SAFE_INTEGER - new Date().getTime();
-        const clientSecret = Number.MAX_SAFE_INTEGER - new Date().getTime();
-        res.status(200).json({
+
+        let serviceAccount = {
           name: req.body.name,
           description: req.body.description,
-          client_id: clientId.toString(),
-          client_secret: clientSecret.toString(),
-        });
+          ...commonServiceAccountFields
+        }
+
+        res.status(200).json(serviceAccount);
+        serviceAccountMap.set(serviceAccount.id, serviceAccount)
+      },
+
+      getServiceAccount: async (c, req, res) => {
+        const id = c.request.params.id;
+        if (!id || !serviceAccountMap.has(id)) {
+          return res.status(400).json({
+            reason: "Missing or invalid id field",
+            ...commonError,
+          });
+        }
+  
+        const serviceAccount = serviceAccountMap.get(id)
+        res.status(204).json(serviceAccount);
+      },
+
+      deleteServiceAccount: async (c, req, res) => {
+        const id = c.request.params.id;
+        if (!id || !serviceAccountMap.has(id)) {
+          return res.status(400).json({
+            reason: "Missing or invalid id field",
+            ...commonError,
+          });
+        }
+  
+        const serviceAccount = serviceAccountMap.get(id)
+        res.status(204).json(serviceAccount);
+        serviceAccountMap.delete(id)
       },
   
       getServiceAccounts: async (c, req, res) => {
-        res.status(200).json(saList);
+        res.status(200).json(serviceAccountList);
       },
   
       
       // Handling auth
       notFound: async (c, req, res) => res.status(404).json({ err: "not found" }),
-      unauthorizedHandler: async (c, req, res) => {
-        res.status(401).json({ err: "unauthorized" })
-    },
+    //   unauthorizedHandler: async (c, req, res) => {
+    //     res.status(401).json({ err: "unauthorized" })
+    // },
     }
   }
 

--- a/packages/api-mock/src/handlers/service-account-manager.js
+++ b/packages/api-mock/src/handlers/service-account-manager.js
@@ -14,6 +14,14 @@ const commonServiceAccountFields = {
     createdAt: new Date().getTime(),
 }
 
+const commonError = {
+  id: "103",
+  kind: "Error",
+  href: "/api/service_account_mgmt/v1/errors/103",
+  code: "SERVICE-ACCOUNT-MGMT-103",
+  operation_id: "1iWIimqGcrDuL61aUxIZqBTqNRa",
+};
+
 function createServiceAccountHandlers(preSeed) {
     
     return {

--- a/packages/api-mock/src/index.js
+++ b/packages/api-mock/src/index.js
@@ -85,7 +85,7 @@ cosAPI.registerSecurityHandler("Bearer", (c, req, res) => {
   return true;
 });
 
-serviceAccountAPI.registerSecurityHandler("Bearer", (c, req, res) => {
+serviceAccountAPI.registerSecurityHandler("bearerAuth", (c, req, res) => {
   return true;
 });
 


### PR DESCRIPTION
## Description
This pr adds endpoints for the service account SDK. You can create, get and delete service accounts with these changes.

## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}

resource "rhoas_service_account" "srvcaccnt" {
  name = "service_account"
}
```
### Commands
For mock server:
- `yarn`
- `yarn build`
- `yarn start`
For terraform provider:
- `make clean`
- `make install`
- `terraform init`
- `LOCAL_DEV=http://localhost:8000 terraform apply`

### Steps
- Run the above commands
- Then delete service account resource in `main.tf`
- Run `LOCAL_DEV=http://localhost:8000 terraform apply` again
- Service account should be deleted

### Expected Results
The service account should be created and then deleted