### PR TITLE
Add basic checks for the service account

### DIFF
--- a/packages/api-mock/src/handlers/service-account-manager.js
+++ b/packages/api-mock/src/handlers/service-account-manager.js
@@ -8,8 +8,6 @@ const commonServiceAccountFields = {
     id: nanoid(),
     clientId: nanoid(),
     secret: nanoid(),
-    name: "service-account-name",
-    description: "service-account-description",
     createdBy: "service-account-created-by",
     createdAt: new Date().getTime(),
 }
@@ -23,9 +21,15 @@ const commonError = {
 };
 
 function createServiceAccountHandlers(preSeed) {
-    
+
     return {
       createServiceAccount: async (c, req, res) => {
+        if (!req.body.name) {
+          return res.status(400).json({
+            reason: "Missing or invalid name field",
+            ...commonError,
+          });
+        }
 
         let serviceAccount = {
           name: req.body.name,
@@ -39,26 +43,41 @@ function createServiceAccountHandlers(preSeed) {
 
       getServiceAccount: async (c, req, res) => {
         const id = c.request.params.id;
-        if (!id || !serviceAccountMap.has(id)) {
+        if (!id) {
           return res.status(400).json({
             reason: "Missing or invalid id field",
             ...commonError,
           });
         }
   
+        if (!serviceAccountMap.has(id)) {
+          console.log(404)
+          return res.status(404).json({
+            reason: "Service account not found",
+            ...commonError,
+          });
+        }
+
         const serviceAccount = serviceAccountMap.get(id)
         res.status(204).json(serviceAccount);
       },
 
       deleteServiceAccount: async (c, req, res) => {
         const id = c.request.params.id;
-        if (!id || !serviceAccountMap.has(id)) {
+        if (!id) {
           return res.status(400).json({
             reason: "Missing or invalid id field",
             ...commonError,
           });
         }
   
+        if (!serviceAccountMap.has(id)) {
+          return res.status(404).json({
+            reason: "Service account not found",
+            ...commonError,
+          });
+        }
+
         const serviceAccount = serviceAccountMap.get(id)
         res.status(204).json(serviceAccount);
         serviceAccountMap.delete(id)


### PR DESCRIPTION
There were no checks for the existence of the service account (404). I added those checks.

I also removed the `name` and `description` from the common params as they were replacing the ones in the request params.