### PR TITLE
Update mock to reproduce Kafka 409 errors

### DIFF
--- a/packages/api-mock/src/handlers/kafka-manager.js
+++ b/packages/api-mock/src/handlers/kafka-manager.js
@@ -75,6 +75,13 @@ function createKafkaHandlers(preSeed) {
         });
       }
 
+      if (Object.keys(kafkas).map(key => kafkas[key].name).includes(req.body.name)) {
+        return res.status(409).json({
+          reason: "The resource already exists",
+          ...commonError,
+        });
+      }
+
       const newId = nanoid();
       const kafka = {
         id: newId,


### PR DESCRIPTION
Update the mock to reproduce the testing steps in https://github.com/redhat-developer/terraform-provider-rhoas/pull/53.