### PR TITLE
Return 400 if the topic name is empty

### DIFF
--- a/packages/api-mock/src/handlers/kafka-admin.js
+++ b/packages/api-mock/src/handlers/kafka-admin.js
@@ -141,6 +141,10 @@ module.exports = {
       return res.status(400).json({ error_message: 'Bad request' });
     }
 
+    if (!topicBody.name) {
+      return res.status(400).json({ error_message: 'Topic name is invalid' });
+    }
+
     let topic = getTopic(topicBody.name);
 
     if (topic) {


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/terraform-provider-rhoas/issues/66