### PR TITLE
fix: adding common kafka fields no longer overwrites request body fields

### DIFF
--- a/packages/api-mock/src/handlers/kafka-manager.js
+++ b/packages/api-mock/src/handlers/kafka-manager.js
@@ -45,6 +45,14 @@ const commonError = {
 
 const kafkas = {};
 
+function addCommonFieldsNotInRequest(kafka) {
+  for(field in commonKafkaFields) {
+    if(kafka[field] == undefined) {
+      kafka[field] = commonKafkaFields[field]
+    }
+  }
+}
+
 function createKafkaHandlers(preSeed) {
   if (preSeed) {
     kafkas['uFYJpM76DaIqVqqgZjtrz'] = {
@@ -87,8 +95,10 @@ function createKafkaHandlers(preSeed) {
         id: newId,
         href: "/api/kafkas_mgmt/v1/kafkas/" + newId,
         ...req.body,
-        ...commonKafkaFields,
       };
+
+      addCommonFieldsNotInRequest(kafka)
+
       kafka["cloud_provider"] = cloudProvider;
       kafkas[newId] = kafka;
       res.status(202).json(kafka);


### PR DESCRIPTION
# Verify
1. Run mock server on `localhost:8000`
2. Log into CLI with mock server as API `rhoas login --api-gateway=http://localhost:8000`