### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/api-update.yaml
+++ b/.github/workflows/api-update.yaml
@@ -41,7 +41,8 @@ jobs:
         run: yarn fetchErrors
       - name: Generate Errors SDK
         run: yarn generateErrors
-      - uses: peter-evans/create-pull-request@v4
+        # v4
+      - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
         with:
             title: "fix(${{ github.event.client_payload.id }}): automated SDK update"
             token: "${{ secrets.CI_USER_TOKEN }}"


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.